### PR TITLE
(fix) Expose `assert.dirs`.

### DIFF
--- a/assert.js
+++ b/assert.js
@@ -17,7 +17,8 @@ module.exports = exports = function(a, b, opts){
 	return equal(a, b, opts || {})
 }
 
-exports.dir = dirs
+/* Deprecated syntax */ exports.dir = dirs;
+exports.dirs = dirs
 exports.file = files
 
 /**


### PR DESCRIPTION
- Exposed `assert.dirs`
- Deprecated `assert.dir`
  - Did not remove `assert.dir` to maintain backwards-compatibility
